### PR TITLE
- add a new buildout configuration attribute "buildout_version"

### DIFF
--- a/opsworks_deploy_python/README.md
+++ b/opsworks_deploy_python/README.md
@@ -50,6 +50,7 @@ The `buildout` recipe sets up, deploys and configures a zc.buildout project from
   - password
   - path (path relative to the deploy location where the archive should be extracted)
   - purge (whether to remove the data and fetch it anew on every deploy or retain it)
+- buildout_version: The buildout version to use for the initial bootstrap command. Defaults to an empty string, which means no version is specified and the bootstrap step will get the latest available version.
 - config: the name of the buildout config file to run.  Defaults to `deploy.cfg`
 - config_template: the name template used to generate the config above.
 - config_cookbook: the cookbook from which to lookup the above template

--- a/opsworks_deploy_python/attributes/buildout.rb
+++ b/opsworks_deploy_python/attributes/buildout.rb
@@ -12,6 +12,7 @@ default["deploy_buildout"]["symlink_before_migrate"] = {
 }
 default["deploy_buildout"]["purge_before_symlink"] = ['var', 'eggs', 'downloads', 'extends', 'parts']
 default["deploy_buildout"]["create_dirs_before_symlink"] = ['var', 'eggs', 'downloads', 'extends', 'parts']
+default["deploy_buildout"]["buildout_version"] = ""
 default["deploy_buildout"]["config"] = "deploy.cfg"
 default["deploy_buildout"]["config_template"] = "deploy.cfg.erb"
 default["deploy_buildout"]["extends"] = ['buildout.cfg']

--- a/opsworks_deploy_python/definitions/buildout_base.rb
+++ b/opsworks_deploy_python/definitions/buildout_base.rb
@@ -53,9 +53,13 @@ define :buildout_configure do
     release_path = ::File.join(deploy[:deploy_to], 'current')
     config_file = Helpers.buildout_setting(deploy,'config', node)
     bootstrap_cmd = "#{::File.join(deploy[:deploy_to], "shared", "env", "bin", "python")} #{::File.join(".", "bootstrap.py")} -c #{config_file}"
+
     buildout_cmd = ::File.join(release_path, "bin", "buildout")
     build_cmd = "#{buildout_cmd} -c #{config_file} #{Helpers.buildout_setting(deploy, 'flags', node)}"
-
+    buildout_version = Helpers.buildout_setting(deploy,'buildout_version', node)
+    if !(buildout_version.nil? || buildout_version.empty?)
+      bootstrap_cmd = "#{bootstrap_cmd} -v #{buildout_version}"
+    end
     services = []
     # Add our anticipated services (or supervisor) to upstart or supervisor
     init_commands = Helpers.buildout_setting(deploy, 'init_commands', node)


### PR DESCRIPTION
- add a new buildout configuration attribute "buildout_version" so the initial bootstrap step can be run with a fixed version requirement, as discussed via email.
