### PR TITLE
Use environment for migration and collectstatic

### DIFF
--- a/opsworks_deploy_python/recipes/django.rb
+++ b/opsworks_deploy_python/recipes/django.rb
@@ -53,6 +53,7 @@ node[:deploy].each do |application, deploy|
       cwd ::File.join(deploy[:deploy_to], 'current')
       user deploy[:user]
       group deploy[:group]
+      environment deploy[:environment_variables]
     end
   end
 
@@ -63,6 +64,7 @@ node[:deploy].each do |application, deploy|
       cwd ::File.join(deploy[:deploy_to], 'current')
       user deploy[:user]
       group deploy[:group]
+      environment deploy[:environment_variables]
     end
   end
 end


### PR DESCRIPTION
If you need certain environment variables for Django to load or for a certain behavior in your application, anything that uses ./manage.py needs to have those environment variables as well. This adds the environment to the two Django execute resources.
