### PR TITLE
WIP: Update Berksfile

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -12,6 +12,7 @@ cookbook 's3fs-fuse', github: 'alecpm/s3fs-fuse'
 
 # We want to be explicit, since we don't explicitly include our
 # packages, except when testing
+cookbook 'iptables', '1.1.0'
 cookbook 'varnish', '0.9.12'
 cookbook 'gunicorn', '1.1.2'
 cookbook 'build-essential', '1.4.2'


### PR DESCRIPTION
attempting to solve a problem with restarting an opsworks instance [caused by a cookbook somewhere that tries to use `compat_resource`](https://github.com/chef-cookbooks/compat_resource/issues/17).  Lots of others reporting this problem is caused by the iptables cookbook, so trying to pin that to fix.